### PR TITLE
use walk instead ll as name for spawn function in bashrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,19 @@ Put the next function into the **.bashrc** or a similar config:
 
 <table>
 <tr>
-  <th> Bash/Zsh </th>
+  <th> Bash </th>
+  <th> Zsh </th>
   <th> Fish </th>
 </tr>
 <tr>
+<td>
+
+```bash
+command -v walk >/dev/null \
+  && function walk { command cd "$(command walk "$@")" || return ;}
+```
+
+</td>
 <td>
 
 ```bash


### PR DESCRIPTION
relates to issue #88 

is also added `|| return` for corner cases where the walk command would f.i. crash and not return a valid path for cd. and added `command cd` for users who have hackerman cd() fuction overrides already defined.